### PR TITLE
Increase sleep time to allow mapd to properly start up

### DIFF
--- a/notebook-demo-docker/demo/packages/utils/start_demo.sh
+++ b/notebook-demo-docker/demo/packages/utils/start_demo.sh
@@ -8,7 +8,7 @@ cmd="nohup ./start_mapd.sh"
 $cmd &disown
 
 echo "Wait for mapd to start"
-sleep 5
+sleep 10
 
 # load data
 echo "Import CSV"


### PR DESCRIPTION
Start demo script is failing because it is trying to issue mapdql commands before the mapd server is ready. Increasing the sleep to 10 seconds fixes the issue in our testing.