### PR TITLE
Pin to conda-build 2.1.10 to avoid bug in conda develop

### DIFF
--- a/notebook-demo-docker/demo/Dockerfile
+++ b/notebook-demo-docker/demo/Dockerfile
@@ -20,7 +20,7 @@ RUN echo $LD_LIBRARY_PATH
 COPY ./packages/pygdf.tar.gz ./pygdf.tar.gz
 RUN tar -xvf ./pygdf.tar.gz
 RUN conda env create -f=pygdf/conda_environments/notebook_py35.yml && conda clean -iltpsy
-RUN conda install conda-build -y
+RUN conda install conda-build=2.1.10 -y
 
 # Add utils script
 COPY ./packages/utils ./utils


### PR DESCRIPTION
This resolves the following error:

```
FileNotFoundError: [Errno 2] No such file or directory: '/home/appuser/Miniconda3/envs/pycudf_notebook_py35/lib/python3.6/site-packages/conda.pth'
```