### PR TITLE
Fix gzip+hardlink issue; misc cleanup

### DIFF
--- a/notebook-demo-docker/demo/packages/utils/create_ipums_easy.sh
+++ b/notebook-demo-docker/demo/packages/utils/create_ipums_easy.sh
@@ -3,5 +3,5 @@ set -e
 cd ~/pygdf/notebooks
 cat ~/pygdf/notebooks/create_table_ipums_easy.txt | ~/mapd/bin/mapdql -p HyperInteractive
 # Import CSV
-gzip -d ipums_easy.csv.gz
+gzip -f -k -d ipums_easy.csv.gz
 echo "COPY ipums_easy FROM '~/pygdf/notebooks/ipums_easy.csv';" | ~/mapd/bin/mapdql -p HyperInteractive

--- a/notebook-demo-docker/demo/packages/utils/start_demo.sh
+++ b/notebook-demo-docker/demo/packages/utils/start_demo.sh
@@ -12,4 +12,4 @@ sleep 10
 
 # load data
 echo "Import CSV"
-./create_ipums_easy.sh
+bash ./create_ipums_easy.sh

--- a/notebook-demo-docker/demo/packages/utils/start_demo_notebook.sh
+++ b/notebook-demo-docker/demo/packages/utils/start_demo_notebook.sh
@@ -1,5 +1,5 @@
 set -e
-~/utils/start_demo.sh
+bash ~/utils/start_demo.sh
 
 source activate pycudf_notebook_py35
 cd ~/pygdf

--- a/notebook-demo-docker/demo/packages/utils/start_mapd.sh
+++ b/notebook-demo-docker/demo/packages/utils/start_mapd.sh
@@ -1,2 +1,2 @@
 cd ~/mapd/
-echo "n" | ./startmapd
+./startmapd --non-interactive


### PR DESCRIPTION
Sorry about bundling unrelated commits - all minor changes that don't really warrant their own PRs. Let me know if you want them split.

---

`gunzip` doesn't like decompressing hardlinks, so you need to add `-f` to force it. This is required for certain Docker storage drivers. Without `-f` you might receive an error similar to

```
gzip: ipums_easy.csv.gz has 8 other links -- unchanged
```
---
Added `--non-interactive` flag when starting MapD instead of echoing `n` through.

Also tell bash to run some of the scripts instead of running them directly since it's possible to lose the executable bit.